### PR TITLE
Revert "Update sbt, sbt-dependency-tree to 1.9.8"

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.9.8
+sbt.version=1.9.7


### PR DESCRIPTION
Reverts grouzen/zio-apache-arrow#57

It causes a build issue:
```
java.lang.UnsatisfiedLinkError: Error looking up function 'stat': java: undefined symbol: stat
```